### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ The database can be created afterwards:
     ./manage.py syncdb
 
 In case additional plugins of django-fluent-contents_ are used, follow their
-`installation instructions <http://django-fluent-contents.readthedocs.org/en/latest/plugins/index.html>`_ as well.
+`installation instructions <https://django-fluent-contents.readthedocs.io/en/latest/plugins/index.html>`_ as well.
 Typically this includes:
 
 * adding the package name to ``INSTALLED_APPS``.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
